### PR TITLE
added alternate ACSL link, fixed typos

### DIFF
--- a/data/documents/advents.html
+++ b/data/documents/advents.html
@@ -970,7 +970,7 @@
     <h5>Boss</h5>
     <p>
         Everlord Wanwan has omni and multihit, with the same build as Lord Wahwah. The difference being, his third hit
-        carries a one-minute long warp instead of knockback; and does only 750 damage.
+        carries a one-minute long warp instead of knockback; and does only 1500 damage.
     </p>
 		
     <h5>Stage Design</h5>
@@ -1275,6 +1275,10 @@
         Fire Slow Beam on base hit. Do note that Iron Wall can work as well, but it's not mentioned as no one has a
         levelled Iron Wall. Maglev should hit the Gabriel in the boss wave, making way for Bahamut and Zamboney to enter
         Clionel's blindspot. If done right, this should be an easy win from here. Keep spamming meatshields and tanks.
+    </p>
+    <p>
+        Alternatively, you can try <a href="https://youtu.be/jL5GwoHyu2w" target="_blank">this</a> approach from
+        Mickey which uses the regular cannon, with a startoff focused on Awakened Bahamut.
     </p>
 
 
@@ -1796,7 +1800,7 @@
     <h5>Boss</h5>
     <p>
         Black Okame is a Red / Black variant of Hannya. And before you even try it, she is Freeze Immune. She has 320
-        Standing Range with omnitstrike up till 800. With 24000 damage and a 2.1s attack frequency, she can disable most
+        Standing Range with omnistrike up till 800. With 24000 damage and a 2.1s attack frequency, she can disable most
         units that aren't tankers. Even slow bulky units like Island or Pizza struggle because of the knockback.
         Finally, she has 2.6M HP with just a single knockback, which means you aren't killing her before peons stop
         cycling [without insane Ubercarry at least].


### PR DESCRIPTION
fixed wanwan damage which was listed as 750 in the third hit
fixed spelling of omnistrike which was given as omnitstrike
added link to Mickey's ACSL rush with regular cannon